### PR TITLE
Add formatting compatibility

### DIFF
--- a/encoder.ts
+++ b/encoder.ts
@@ -36,7 +36,7 @@ export function decodeEmptyLines(text:string, emptyLineMarker?:string, newLine?:
 
     var lines = text.split(/\r?\n/);
 
-    const uncommentedLines = lines.map(line => line == marker ? '' : line);
+    const uncommentedLines = lines.map(line => line.trim() == marker ? '' : line);
     
     return uncommentedLines.join(newLine || EmptyLineEncoder.defaultNewLine);
 }


### PR DESCRIPTION
Trims the lines during decoding prior to comment detection in order to handle indentation that the TS printer may apply to the comment